### PR TITLE
Issue #18: Preserve fragment links for JavaScript controls

### DIFF
--- a/classes/customcleanurl.php
+++ b/classes/customcleanurl.php
@@ -131,8 +131,13 @@ document.addEventListener('click', function (event) {
         }
         element = element.parentElement;
     }
-    if (element.getAttribute('href').charAt(0) == '#') {
-        element.href = '{$clean}' + element.getAttribute('href');
+    var href = element.getAttribute('href');
+    var iscontrol = element.getAttribute('role') === 'button'
+        || element.hasAttribute('data-action')
+        || element.hasAttribute('data-toggle')
+        || element.hasAttribute('data-bs-toggle');
+    if (href && href.charAt(0) == '#' && !iscontrol) {
+        element.href = '{$clean}' + href;
     }
 }, true);
 </script>


### PR DESCRIPTION
## Summary

  Fixes issue #18, where Moodle topic collapse and expand buttons stop working when clean URLs are enabled.

  The plugin was changing internal fragment links used by Moodle’s JavaScript controls into complete URLs. Moodle then could not find the related topic element.

  This change skips URL rewriting for JavaScript controls while keeping the existing behavior for normal anchor links.

  ## Testing

  - Tested on Moodle 4.5.13.
  - Confirmed topics collapse and expand correctly.
  - Confirmed the topic state remains synchronized.
  - PHP syntax check passed.
