### PR TITLE
Refactor custom clean URL functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.0", "8.1", "8.2"]
-        moodle-branch: ["MOODLE_402_STABLE"]
+        php: ["8.1", "8.2"]
+        moodle-branch: ["MOODLE_405_STABLE", "MOODLE_502_STABLE"]
         database: [pgsql, mariadb]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: plugin
 
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload Behat Faildump
         if: ${{ failure() && steps.behat.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Behat Faildump (${{ join(matrix.*, ', ') }})
           path: ${{ github.workspace }}/moodledata/behat_dump

--- a/404.php
+++ b/404.php
@@ -25,6 +25,7 @@
 
 use local_customcleanurl\local\helper;
 
+// phpcs:ignore moodle.Files.RequireLogin.Missing -- This endpoint is intentionally public.
 // Get require config file.
 require_once(dirname(__FILE__) . '/../../config.php');
 

--- a/404.php
+++ b/404.php
@@ -25,8 +25,6 @@
 
 use local_customcleanurl\local\helper;
 
-define('NO_MOODLE_COOKIES', true);
-
 // Get require config file.
 require_once(dirname(__FILE__) . '/../../config.php');
 

--- a/404.php
+++ b/404.php
@@ -25,8 +25,8 @@
 
 use local_customcleanurl\local\helper;
 
-// phpcs:ignore moodle.Files.RequireLogin.Missing -- This endpoint is intentionally public.
 // Get require config file.
+// phpcs:ignore moodle.Files.RequireLogin.Missing -- This endpoint is intentionally public.
 require_once(dirname(__FILE__) . '/../../config.php');
 
 // Prepare the page information.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Release notes
 
+### Version 1.1.7 (2026092800)
+* Add a Define Custom URL link to secondary navigation
+* Add capability checks for managing custom URLs and URL redirects
+* Update CI configuration and clean up code formatting
+
 ### Version 1.1.6 (2026091500)
 * Fix Moodle topic collapse buttons
 

--- a/README.md
+++ b/README.md
@@ -79,44 +79,6 @@ location / {
 }
 ```
 
-#### Recommended full example (common Moodle + PHP-FPM setup)
-
-```nginx
-server {
-    listen 80;
-    # listen 443 ssl http2;   # enable if using SSL
-    server_name your_domain.com;
-
-    root /path/to/moodle;
-    index index.php index.html;
-
-    client_max_body_size 200M;
-
-    # Clean URL routing via customcleanurl
-    location / {
-        try_files $uri $uri/ /local/customcleanurl/route.php?$query_string;
-    }
-
-    # PHP handling
-    location ~ [^/]\.php(/|$) {
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
-        fastcgi_pass unix:/run/php/php8.2-fpm.sock;   # adjust to your PHP version
-    }
-
-    # Optional: Custom error pages
-    error_page 403 /local/customcleanurl/404.php;
-    error_page 404 /local/customcleanurl/404.php;
-
-    # Deny access to hidden files
-    location ~ /\. {
-        deny all;
-    }
-}
-```
-
 > After changing the Nginx config, test and reload:
 > ```bash
 > sudo nginx -t

--- a/classes/form/customcleanurl_form.php
+++ b/classes/form/customcleanurl_form.php
@@ -90,7 +90,7 @@ class customcleanurl_form extends \moodleform {
         $mform->addElement('hidden', 'type');
         $mform->setType('type', PARAM_TEXT);
         $mform->setDefault('type', $type);
-      
+
         $mform->addElement('hidden', 'returnurl');
         $mform->setType('returnurl', PARAM_URL);
         $mform->setDefault('returnurl', '');

--- a/classes/form/customcleanurl_form.php
+++ b/classes/form/customcleanurl_form.php
@@ -90,6 +90,11 @@ class customcleanurl_form extends \moodleform {
         $mform->addElement('hidden', 'type');
         $mform->setType('type', PARAM_TEXT);
         $mform->setDefault('type', $type);
+      
+        $mform->addElement('hidden', 'returnurl');
+        $mform->setType('returnurl', PARAM_URL);
+        $mform->setDefault('returnurl', '');
+
     }
 
     /**
@@ -172,13 +177,17 @@ class customcleanurl_form extends \moodleform {
                     $errors['custom_url'] = get_string('error_default_url_alrady_clean', 'local_customcleanurl', $a);
                 } else {
                     $customurl = str_replace($CFG->wwwroot, '', trim($data['custom_url']));
-                    $existing = $DB->get_record($dbtable, [
-                        'custom_url' => $customurl,
-                        'cleanurl_type' => 'defineurl',
-                    ]);
-                    if ($existing) {
-                        if (!$data['id'] || $existing->id != $data['id']) {
-                            $errors['custom_url'] = get_string('error_custom_exist', 'local_customcleanurl', $a);
+                    if (strlen($customurl) >= 225) {
+                        $errors['custom_url'] = get_string('error_url_too_long', 'local_customcleanurl');
+                    } else {
+                        $existing = $DB->get_record($dbtable, [
+                            'custom_url' => $customurl,
+                            'cleanurl_type' => 'defineurl',
+                        ]);
+                        if ($existing) {
+                            if (!$data['id'] || $existing->id != $data['id']) {
+                                $errors['custom_url'] = get_string('error_custom_exist', 'local_customcleanurl', $a);
+                            }
                         }
                     }
                 }

--- a/classes/form/customcleanurl_form.php
+++ b/classes/form/customcleanurl_form.php
@@ -94,7 +94,6 @@ class customcleanurl_form extends \moodleform {
         $mform->addElement('hidden', 'returnurl');
         $mform->setType('returnurl', PARAM_URL);
         $mform->setDefault('returnurl', '');
-
     }
 
     /**

--- a/classes/handler/customcleanurl_handler.php
+++ b/classes/handler/customcleanurl_handler.php
@@ -265,7 +265,6 @@ class customcleanurl_handler {
         $table->setup();
 
         if ($cleanurltype == 'defineurl') {
-
             // Build the filter form.
             $filterform = html_writer::start_tag('form', [
                 'method' => 'get',
@@ -318,7 +317,8 @@ class customcleanurl_handler {
             ]);
             $filterform .= html_writer::end_div();
 
-            $filterform .= html_writer::end_div(); // end .row
+            $filterform .= html_writer::end_div(); 
+            // ... end div.row
 
             // Buttons on their own row below the fields.
             $filterform .= html_writer::start_div('row mt-2');

--- a/classes/handler/customcleanurl_handler.php
+++ b/classes/handler/customcleanurl_handler.php
@@ -317,7 +317,7 @@ class customcleanurl_handler {
             ]);
             $filterform .= html_writer::end_div();
 
-            $filterform .= html_writer::end_div(); 
+            $filterform .= html_writer::end_div();
             // ... end div.row
 
             // Buttons on their own row below the fields.

--- a/classes/handler/customcleanurl_handler.php
+++ b/classes/handler/customcleanurl_handler.php
@@ -64,8 +64,9 @@ class customcleanurl_handler {
                 $data->default_url = str_replace($CFG->wwwroot, '', trim($mformdata->default_url));
                 $data->default_url = rtrim($data->default_url, '/');
                 $data->custom_url = str_replace($CFG->wwwroot, '', trim($mformdata->custom_url));
-
                 $data->timemodified = time();
+
+                $returnurl = !empty($mformdata->returnurl) ? $mformdata->returnurl : $returnurl;
 
                 if ($data->id && ($data->action == 'edit')) {
                     $dataexists = $DB->record_exists(self::$dbtable, ['id' => $data->id]);
@@ -83,7 +84,7 @@ class customcleanurl_handler {
                     }
                 }
             } catch (\Throwable $th) {
-                $message = get_string('data_saved_error', 'local_customcleanurl');
+                $message = get_string('data_saved_error', 'local_customcleanurl') . " : " . $th->getMessage();
             }
         }
         if (!$message) {
@@ -157,6 +158,53 @@ class customcleanurl_handler {
     }
 
     /**
+     * Populate the add form.
+     *
+     * @param \moodleform $mform     The Moodle form instance.
+     * @return void Outputs form UI or redirects if record is missing.
+     */
+    public static function add_form($mform) {
+        global $OUTPUT, $DB, $CFG;
+
+        $defaulturlpath = optional_param('default_url', '', PARAM_PATH);
+        $returnurl = optional_param('returnurl', '', PARAM_URL);
+        $clearurl = '';
+        if ($defaulturlpath) {
+            $defaultmoodleurl = new moodle_url($defaulturlpath);
+            $data = $DB->get_record(
+                'local_customcleanurl',
+                [
+                    'default_url' => $defaulturlpath,
+                    'cleanurl_type' => 'defineurl',
+                ],
+            );
+            if ($data) {
+                $clearurl = $data->custom_url;
+            } else {
+                $clearurl = str_replace($CFG->wwwroot, '', $defaultmoodleurl->out());
+            }
+        }
+
+        $entry = new stdClass();
+        $entry->id = isset($data->id) ? $data->id : 0;
+        $entry->default_url = $defaulturlpath;
+        $entry->custom_url = rawurldecode($clearurl);
+        $entry->returnurl = $returnurl;
+        $entry->action = 'edit';
+        $mform->set_data($entry);
+
+        // ... output content
+        echo $OUTPUT->header();
+        echo html_writer::start_tag('div', ['class' => 'add-custom-url-wrapper mt-4 mb-4']);
+        echo html_writer::tag('h3', get_string('edit_custom_url_title', 'local_customcleanurl'));
+        $mform->display();
+        echo html_writer::end_tag('div');
+
+        echo $OUTPUT->footer();
+        die;
+    }
+
+    /**
      * Generate and return a paginated table of custom clean URLs.
      *
      * @param string $pagepath
@@ -167,7 +215,20 @@ class customcleanurl_handler {
     public static function get_custom_url_data_table($pagepath, int $perpage = 12, $cleanurltype = 'defineurl') {
         global $CFG, $DB, $PAGE;
         $outputdata = '';
-        $pageurl = new moodle_url($pagepath);
+
+        // Read filter values from the request.
+        $filterdefaulturl = optional_param('filter_default_url', '', PARAM_RAW);
+        $filtercustomurl  = optional_param('filter_custom_url', '', PARAM_RAW);
+
+        // Base url must carry the current filters so sorting/paging doesn't lose them.
+        $pageurl = new moodle_url($pagepath, ['cleanurltype' => $cleanurltype]);
+        if ($filterdefaulturl !== '') {
+            $pageurl->param('filter_default_url', $filterdefaulturl);
+        }
+        if ($filtercustomurl !== '') {
+            $pageurl->param('filter_custom_url', $filtercustomurl);
+        }
+
         // ... table generate.
         require_once($CFG->libdir . '/tablelib.php');
         $table = new flexible_table('moodle-clean-custom-url-data');
@@ -177,11 +238,12 @@ class customcleanurl_handler {
             'custom_url',
             'action',
         ];
+        $customurlheader = ($cleanurltype == 'defineurl') ?
+            get_string('custom_url', 'local_customcleanurl') : get_string('redirect_url', 'local_customcleanurl');
         $tableheaders = [
             get_string('sn', 'local_customcleanurl'),
             get_string('default_url', 'local_customcleanurl'),
-            ($cleanurltype == 'defineurl') ?
-                get_string('custom_url', 'local_customcleanurl') : get_string('redirect_url', 'local_customcleanurl'),
+            $customurlheader,
             get_string('action'),
         ];
         $table->define_columns($tablecolumns);
@@ -201,18 +263,114 @@ class customcleanurl_handler {
         $table->no_sorting('action');
         $table->no_sorting('id');
         $table->setup();
-        $table->pagesize($perpage, $DB->count_records(self::$dbtable, ['cleanurl_type' => $cleanurltype]));
+
+        if ($cleanurltype == 'defineurl') {
+
+            // Build the filter form.
+            $filterform = html_writer::start_tag('form', [
+                'method' => 'get',
+                'action' => (new moodle_url($pagepath))->out(false),
+                'class' => 'mb-3',
+            ]);
+
+            // Hidden field so the current tab/type survives the GET submit.
+            $filterform .= html_writer::empty_tag('input', [
+                'type' => 'hidden',
+                'name' => 'cleanurltype',
+                'value' => $cleanurltype,
+            ]);
+
+            $filterform .= html_writer::start_div('row');
+
+            // Moodle URL filter.
+            $filterform .= html_writer::start_div('col-12 col-md-6');
+            $filterform .= html_writer::label(
+                get_string('default_url', 'local_customcleanurl'),
+                'filter_default_url',
+                true,
+                ['class' => 'font-weight-normal']
+            );
+            $filterform .= html_writer::empty_tag('input', [
+                'type' => 'text',
+                'id' => 'filter_default_url',
+                'name' => 'filter_default_url',
+                'value' => $filterdefaulturl,
+                'class' => 'form-control',
+                'placeholder' => 'Search Moodle URL',
+            ]);
+            $filterform .= html_writer::end_div();
+
+            // Custom URL filter.
+            $filterform .= html_writer::start_div('col-12 col-md-6');
+            $filterform .= html_writer::label(
+                $customurlheader,
+                'filter_custom_url',
+                true,
+                ['class' => 'font-weight-normal']
+            );
+            $filterform .= html_writer::empty_tag('input', [
+                'type' => 'text',
+                'id' => 'filter_custom_url',
+                'name' => 'filter_custom_url',
+                'value' => $filtercustomurl,
+                'class' => 'form-control',
+                'placeholder' => 'Search Custom URL',
+            ]);
+            $filterform .= html_writer::end_div();
+
+            $filterform .= html_writer::end_div(); // end .row
+
+            // Buttons on their own row below the fields.
+            $filterform .= html_writer::start_div('row mt-2');
+            $filterform .= html_writer::start_div('col-12 d-flex justify-content-start');
+            $filterform .= html_writer::tag(
+                'button',
+                get_string('search'),
+                [
+                    'type' => 'submit',
+                    'class' => 'btn btn-primary me-2',
+                ]
+            );
+            $clearurl = new moodle_url($pagepath, ['cleanurltype' => $cleanurltype]);
+            $filterform .= html_writer::link(
+                $clearurl,
+                get_string('clear'),
+                [
+                    'class' => 'btn btn-secondary',
+                ]
+            );
+            $filterform .= html_writer::end_div();
+            $filterform .= html_writer::end_div();
+
+            $filterform .= html_writer::end_tag('form');
+            // End filter form.
+        }
+
+        // Build WHERE clause including filters.
+        $where = 'cleanurl_type = :cleanurltype';
+        $sqlparams = ['cleanurltype' => $cleanurltype];
+        if ($filterdefaulturl !== '') {
+            $where .= ' AND ' . $DB->sql_like('default_url', ':filterdefaulturl', false, false);
+            $sqlparams['filterdefaulturl'] = '%' . $DB->sql_like_escape($filterdefaulturl) . '%';
+        }
+        if ($filtercustomurl !== '') {
+            $where .= ' AND ' . $DB->sql_like('custom_url', ':filtercustomurl', false, false);
+            $sqlparams['filtercustomurl'] = '%' . $DB->sql_like_escape($filtercustomurl) . '%';
+        }
+
+        $table->pagesize($perpage, $DB->count_records_select(self::$dbtable, $where, $sqlparams));
         $limitfrom = $table->get_page_start();
         $limitnum = $table->get_page_size();
         if (isset($_GET['ssort']) && $table->get_sql_sort()) {
             $sort = $table->get_sql_sort();
         } else {
-            $sort = 'id DESC';
+            $sort = 'timemodified DESC';
         }
         // ... get data from db.
-        $datarecords = $DB->get_records(
+        $datarecords = $DB->get_records_select(
             self::$dbtable,
-            ['cleanurl_type' => $cleanurltype],
+            $where,
+            $sqlparams,
             $sort,
             $fields = '*',
             $limitfrom,
@@ -255,7 +413,7 @@ class customcleanurl_handler {
             }
         }
         $table->finish_output();
-        $outputdata = ob_get_contents();
+        $outputdata = $filterform . ob_get_contents();
         ob_end_clean();
 
         $PAGE->requires->js_call_amd('local_customcleanurl/customcleanurl', 'conformdelete');

--- a/classes/hooks/hook_callbacks.php
+++ b/classes/hooks/hook_callbacks.php
@@ -15,6 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Hook callbacks for local_customcleanurl.
  *
  * @package    local_customcleanurl
  * @copyright  2025 https://santoshmagar.com.np/
@@ -26,42 +27,61 @@
 namespace local_customcleanurl\hooks;
 
 use core\hook\output\before_http_headers;
+use local_customcleanurl\local\helper;
 
 /**
- * Hook callbacks for local_customcleanurl
+ * Hook callbacks for local_customcleanurl.
  *
  * @package    local_customcleanurl
- * @copyright  2025 santoshtmp <https://santoshmagar.com.np/>
+ * @copyright  2025 https://santoshmagar.com.np/
  * @author     santoshtmp
- * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class hook_callbacks {
     /**
-     * Callback allowing to before_http_headers
+     * Callback for before_http_headers.
      *
-     * @param \core\hook\output\before_http_headers $hook
+     * @param before_http_headers $hook
      */
     public static function before_http_headers(before_http_headers $hook): void {
-        global $CFG;
+        global $CFG, $PAGE;
+
         if (during_initial_install() || isset($CFG->upgraderunning)) {
             // Do nothing during installation or upgrade.
             return;
         }
-        if (class_exists("\local_customcleanurl\local\helper")) {
-            \local_customcleanurl\local\helper::urlrewriteclass_initialize();
+
+        if (class_exists(\local_customcleanurl\local\helper::class)) {
+            helper::urlrewriteclass_initialize();
         }
-        \local_customcleanurl\local\helper::urlredirect_initialize();
+        helper::urlredirect_initialize();
+
+        helper::add_define_custom_url_node($PAGE->secondarynav);
     }
 
-
     /**
-     * Callback allowing to add contetnt inside the region-main, in the very end
+     * Callback for after_config.
+     *
+     * Ensures the custom URL rewrite class is initialised after config is loaded.
      *
      * @param \core\hook\after_config $hook
      */
     public static function after_config(\core\hook\after_config $hook): void {
-        if (class_exists("\local_customcleanurl\local\helper")) {
-            \local_customcleanurl\local\helper::urlrewriteclass_initialize();
+        if (class_exists(\local_customcleanurl\local\helper::class)) {
+            helper::urlrewriteclass_initialize();
         }
     }
+
+    /**
+     * Callback for secondary_extend.
+     *
+     * Adds the "Define custom URL" node on pages that build secondary
+     * navigation through core (course, module, category, site admin, etc.).
+     *
+     * @param \core\hook\navigation\secondary_extend $hook
+     */
+    public static function extend_secondary_navigation(\core\hook\navigation\secondary_extend $hook): void {
+        helper::add_define_custom_url_node($hook->get_secondaryview());
+    }
+
 }

--- a/classes/hooks/hook_callbacks.php
+++ b/classes/hooks/hook_callbacks.php
@@ -83,5 +83,4 @@ class hook_callbacks {
     public static function extend_secondary_navigation(\core\hook\navigation\secondary_extend $hook): void {
         helper::add_define_custom_url_node($hook->get_secondaryview());
     }
-
 }

--- a/classes/local/clean_url.php
+++ b/classes/local/clean_url.php
@@ -156,8 +156,17 @@ class clean_url {
                 ],
             );
             if ($checkcustomurlpath) {
-                $this->path = $checkcustomurlpath->custom_url;
+                // $this->path = $checkcustomurlpath->custom_url;
+                $this->path = implode(
+                    '/',
+                    array_map(
+                        'rawurlencode',
+                        explode('/', $checkcustomurlpath->custom_url)
+                    )
+                );
+
                 $this->params = [];
+                return;
             }
         }
 
@@ -222,7 +231,7 @@ class clean_url {
             $course = $DB->get_record('course', ['id' => $courseid]);
             if ($course) {
                 unset($this->params['id']);
-                $cleannewpath = $cleannewpath . '/' . urlencode(strtolower($course->shortname));
+                $cleannewpath = $cleannewpath . '/' . rawurlencode(strtolower($course->shortname));
                 if ($this->check_path_allowed($cleannewpath)) {
                     $this->path = $cleannewpath;
                 }
@@ -232,7 +241,7 @@ class clean_url {
             if ($coursecategories) {
                 unset($this->params['categoryid']);
                 $cleannewpath = $cleannewpath . '/category/' . $coursecategories->id .
-                    '/' . urlencode(strtolower($coursecategories->name));
+                    '/' . rawurlencode(strtolower($coursecategories->name));
                 if ($this->check_path_allowed($cleannewpath)) {
                     $this->path = $cleannewpath;
                 }
@@ -268,7 +277,7 @@ class clean_url {
         if ($user) {
             unset($this->params['id']);
             $cleannewpath = $this->remove_index_php();
-            $cleannewpath = $cleannewpath . '/' . urlencode(strtolower($user->username));
+            $cleannewpath = $cleannewpath . '/' . rawurlencode(strtolower($user->username));
             if ($this->check_path_allowed($cleannewpath)) {
                 $this->path = $cleannewpath;
             }

--- a/classes/local/clean_url.php
+++ b/classes/local/clean_url.php
@@ -156,7 +156,6 @@ class clean_url {
                 ],
             );
             if ($checkcustomurlpath) {
-                // ... $this->path = $checkcustomurlpath->custom_url;
                 $this->path = implode(
                     '/',
                     array_map(

--- a/classes/local/clean_url.php
+++ b/classes/local/clean_url.php
@@ -180,7 +180,7 @@ class clean_url {
 
         // For cleanurl_type = userurl.
         if (in_array('userurl', $cleanurltype)) {
-            // Url path start with /course.
+            // Url path start with /user.
             if (preg_match('#^' . $CFG->subdirpath . '/user/profile.php#', $this->path, $matches)) {
                 $this->clean_users_profile_url();
                 return;

--- a/classes/local/clean_url.php
+++ b/classes/local/clean_url.php
@@ -156,7 +156,7 @@ class clean_url {
                 ],
             );
             if ($checkcustomurlpath) {
-                // $this->path = $checkcustomurlpath->custom_url;
+                // ... $this->path = $checkcustomurlpath->custom_url;
                 $this->path = implode(
                     '/',
                     array_map(

--- a/classes/local/helper.php
+++ b/classes/local/helper.php
@@ -384,6 +384,10 @@ class helper {
             return;
         }
 
+        if (!has_capability('local/customcleanurl:managecustomcleanurl', $PAGE->context)) {
+            return;
+        }
+
         // Prevent duplicate.
         if ($secondaryview->find('local_customcleanurl', null)) {
             return;

--- a/classes/local/helper.php
+++ b/classes/local/helper.php
@@ -118,10 +118,6 @@ class helper {
      */
     public static function check_requesturl($requesturl) {
         global $CFG, $DB;
-        $subdirpath = (new \moodle_url($CFG->wwwroot))->get_path(false);
-        $requestmoodleurl = new moodle_url(rtrim($requesturl, "/"));
-        $requestpath = $requestmoodleurl->get_path(false);
-        $requestpath = urldecode(str_replace($subdirpath, '', $requestpath));
 
         $responsedata = [
             'status' => true,
@@ -132,20 +128,25 @@ class helper {
             'urltype' => '',
         ];
 
+        // Bail out early if the feature is disabled site-wide.
         if (!self::is_enable_customcleanurl()) {
             $responsedata['status'] = false;
             $responsedata['message'] = get_string('featureisnotenable', 'local_customcleanurl');
             return $responsedata;
         }
 
-        $parts = explode("/", trim($requestpath, '/'));
-        $uniquename = urldecode(end($parts));
         $responseuri = '';
 
         $cleanurltype = get_config('local_customcleanurl', 'cleanurl_type');
         $cleanurltype = explode(",", $cleanurltype);
 
-        // Case 1: Admin-defined custom mapping (defineurl).
+        $subdirpath = (new \moodle_url($CFG->wwwroot))->get_path(false);
+        $requestmoodleurl = new moodle_url(rtrim($requesturl, "/"));
+        $requestpath = $requestmoodleurl->get_path(false);
+        $requestpath = str_replace($subdirpath, '', $requestpath);
+
+        // Case 1: Admin-defined custom mapping (defineurl) — highest priority,
+        // checked first so an explicit mapping always wins over pattern matching.
         if (in_array('defineurl', $cleanurltype)) {
             $checkcustomurlpath = $DB->get_record(
                 'local_customcleanurl',
@@ -154,29 +155,60 @@ class helper {
                     'cleanurl_type' => 'defineurl',
                 ],
             );
+            if (!$checkcustomurlpath) {
+                $decoderequestpath =  implode(
+                    '/',
+                    array_map(
+                        'rawurldecode',
+                        explode('/', $requestpath)
+                    )
+                );
+                $checkcustomurlpath = $DB->get_record(
+                    'local_customcleanurl',
+                    [
+                        'custom_url' => $decoderequestpath,
+                        'cleanurl_type' => 'defineurl',
+                    ],
+                );
+            }
+
             if ($checkcustomurlpath) {
                 $responseuri = $checkcustomurlpath->default_url;
             }
         }
 
-        // Case 2: Course-related URLs (courseurl).
-        if (in_array('courseurl', $cleanurltype) && !$responseuri && $parts[0] === 'course') {
-            $course = $DB->get_record('course', ['shortname' => $uniquename]);
-            if ($course && count($parts) === 2) {
-                $responseuri = "/course/view.php?id=" . $course->id;
-            } else if ($course && count($parts) === 3 && $parts[1] === 'edit') {
-                $responseuri = "/course/edit.php?id=" . $course->id;
-            } else if (count($parts) === 4) {
-                $coursecategories = $DB->get_record('course_categories', ['id' => $parts[2]]);
-                $responseuri = "/course/index.php?categoryid=" . $coursecategories->id;
-            }
-        }
+        // Only fall through to pattern-based resolution if no explicit
+        // mapping was found above.
+        if (!$responseuri) {
+            $parts = explode("/", trim($requestpath, '/'));
+            $uniquename = rawurldecode(end($parts));
 
-        // Case 3: User profile URLs (userurl).
-        if (in_array('userurl', $cleanurltype) && !$responseuri && $parts[0] === 'user') {
-            $user = $DB->get_record('user', ['username' => $uniquename]);
-            if ($user && count($parts) === 3) {
-                $responseuri = "/user/profile.php?id=" . $user->id;
+            // Case 2: Course-related URLs (courseurl).
+            // Supported shapes: course/{shortname}, course/edit/{shortname},
+            // course/index/{categoryid}/{name}.
+            if (in_array('courseurl', $cleanurltype) && !$responseuri && $parts[0] === 'course') {
+                $course = $DB->get_record('course', ['shortname' => $uniquename]);
+                if ($course && count($parts) === 2) {
+                    $responseuri = "/course/view.php?id=" . $course->id;
+                } else if ($course && count($parts) === 3 && $parts[1] === 'edit') {
+                    $responseuri = "/course/edit.php?id=" . $course->id;
+                } else if (count($parts) === 4) {
+                    $coursecategories = $DB->get_record('course_categories', ['id' => $parts[2]]);
+                    // Guard against a missing category to avoid a warning
+                    // when dereferencing a false result.
+                    if ($coursecategories) {
+                        $responseuri = "/course/index.php?categoryid=" . $coursecategories->id;
+                    }
+                }
+            }
+
+            // Case 3: User profile URLs (userurl).
+            // Supported shape: user/{something}/{username}.
+            if (in_array('userurl', $cleanurltype) && !$responseuri && $parts[0] === 'user') {
+                $user = $DB->get_record('user', ['username' => $uniquename]);
+                if ($user && count($parts) === 3) {
+                    $responseuri = "/user/profile.php?id=" . $user->id;
+                }
             }
         }
 
@@ -185,6 +217,10 @@ class helper {
             $requestparam = $requestmoodleurl->params();
 
             $responseurl = new moodle_url($responseuri);
+
+            // Reject the match if any param on the resolved URL is also
+            // present on the incoming request — that's an ambiguous
+            // collision rather than a clean match.
             foreach ($responseurl->params() as $k => $v) {
                 if (array_key_exists($k, $requestparam)) {
                     $a = new stdClass();
@@ -195,10 +231,12 @@ class helper {
                     return $responsedata;
                 }
             }
+
             $rawresponsepath = $responseurl->get_path(false);
             $responsepath = str_starts_with($rawresponsepath, $subdirpath)
                 ? substr($rawresponsepath, strlen($subdirpath))
                 : $rawresponsepath;
+
             $responsedata['urltype'] = self::geturlpathtype($responsepath);
             $responsedata['filepath'] = $CFG->dirroot . $responsepath;
             $responsedata['param'] = $responseurl->params();
@@ -208,6 +246,7 @@ class helper {
         }
 
         // Directory as path - check for index files.
+        // Fallback 1: request path maps to a real directory.
         $dirpath = $CFG->dirroot . $requestpath;
         if (is_dir($dirpath)) {
             $files = scandir($dirpath);
@@ -222,7 +261,7 @@ class helper {
             }
         }
 
-        // Check if PHP file exists in the path.
+        // Fallback 2: request path already names a real PHP file on disk.
         if (str_contains($requestpath, '.php')) {
             $filepath = $CFG->dirroot . explode('.php', $requestpath)[0] . '.php';
             if (file_exists($filepath)) {
@@ -232,13 +271,13 @@ class helper {
             }
         }
 
-        // Handle customcleanurl route test endpoint.
+        // Fallback 3: built-in route test endpoint for verifying clean URLs work.
         if ($requestpath == '/customcleanurl/routetest') {
             $responsedata['urltype'] = 'customcleanurl_routetest';
             return $responsedata;
         }
 
-        // Return 404 if no matching path is found.
+        // Nothing matched — report a 404.
         $responsedata['urltype'] = '404';
         $responsedata['filepath'] = $CFG->dirroot . '/local/customcleanurl/404.php';
         return $responsedata;
@@ -327,5 +366,70 @@ class helper {
                 redirect(new moodle_url($checkcustomurlpath->custom_url));
             }
         }
+    }
+
+    /**
+     * Add the "Define custom URL" node to a secondary navigation tree.
+     *
+     * Shared entry point used by both secondary_extend and before_http_headers.
+     * Skips pages without secondary navigation, excluded layouts, and when the
+     * defineurl feature is disabled. Prevents duplicate nodes.
+     *
+     * @param \navigation_node $secondaryview Secondary navigation root node.
+     */
+    public static function add_define_custom_url_node(\navigation_node $secondaryview): void {
+        global $PAGE, $CFG;
+
+        if (!$PAGE->has_secondary_navigation()) {
+            return;
+        }
+
+        // Prevent duplicate.
+        if ($secondaryview->find('local_customcleanurl', null)) {
+            return;
+        }
+
+        $currentpagelayout = $PAGE->pagelayout;
+        if (in_array($currentpagelayout, ['frontpage', 'admin'], true)) {
+            return;
+        }
+
+        if ($currentpagelayout === 'coursecategory') {
+            $categoryid = optional_param('categoryid', 0, PARAM_INT);
+            if (empty($categoryid)) {
+                return;
+            }
+        }
+
+        $cleanurltype = get_config('local_customcleanurl', 'cleanurl_type');
+        $cleanurltype = explode(',', (string) $cleanurltype);
+
+        // Only when defineurl is enabled.
+        if (!in_array('defineurl', $cleanurltype, true)) {
+            return;
+        }
+
+        $pagerawurl = str_replace($CFG->wwwroot, '', $PAGE->url->raw_out(false));
+
+        $url = new \moodle_url('/local/customcleanurl/define_custom_url.php', [
+            'action'      => 'edit',
+            'sesskey'     => sesskey(),
+            'default_url' => $pagerawurl,
+            'returnurl'   => $pagerawurl,
+        ]);
+
+        $node = \navigation_node::create(
+            get_string('define_custom_url', 'local_customcleanurl'),
+            $url,
+            \navigation_node::TYPE_SETTING,
+            null,
+            'local_customcleanurl',
+            new \pix_icon('i/settings', '')
+        );
+
+        $node->showinsecondarynavigation = true;
+        $node->display = true;
+
+        $secondaryview->add_node($node);
     }
 }

--- a/classes/local/helper.php
+++ b/classes/local/helper.php
@@ -156,7 +156,7 @@ class helper {
                 ],
             );
             if (!$checkcustomurlpath) {
-                $decoderequestpath =  implode(
+                $decoderequestpath = implode(
                     '/',
                     array_map(
                         'rawurldecode',

--- a/classes/local/helper.php
+++ b/classes/local/helper.php
@@ -203,7 +203,7 @@ class helper {
             }
 
             // Case 3: User profile URLs (userurl).
-            // Supported shape: user/{something}/{username}.
+            // Supported shape: user/profile/{username}.
             if (in_array('userurl', $cleanurltype) && !$responseuri && $parts[0] === 'user') {
                 $user = $DB->get_record('user', ['username' => $uniquename]);
                 if ($user && count($parts) === 3) {

--- a/db/access.php
+++ b/db/access.php
@@ -26,8 +26,16 @@
 defined('MOODLE_INTERNAL') || die();
 
 $capabilities = [
-    // Capability to manage custom clean url.
+    // Capability to manage custom URL mappings.
     'local/customcleanurl:managecustomcleanurl' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+    ],
+    // Capability to manage URL redirects.
+    'local/customcleanurl:manageurlredirect' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_SYSTEM,
         'archetypes' => [

--- a/db/access.php
+++ b/db/access.php
@@ -15,33 +15,23 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Hook callbacks
- * https://moodledev.io/docs/4.5/apis/core/hooks
- * https://docs.moodle.org/dev/Callbacks
+ * Capabilities for local_customcleanurl plugin.
  *
  * @package    local_customcleanurl
- * @copyright  2025 https://santoshmagar.com.np/
- * @author     santoshtmp
+ * @copyright  2026 https://santoshmagar.com.np/
+ * @author     santoshmagar.com.np
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- *
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$callbacks = [
-    [
-        'hook' => core\hook\output\before_http_headers::class,
-        'callback' => [local_customcleanurl\hooks\hook_callbacks::class, 'before_http_headers'],
-        'priority' => 0,
-    ],
-    [
-        'hook' => core\hook\after_config::class,
-        'callback' => [local_customcleanurl\hooks\hook_callbacks::class, 'after_config'],
-        'priority' => 0,
-    ],
-    [
-        'hook'     => \core\hook\navigation\secondary_extend::class,
-        'callback' => [\local_customcleanurl\hooks\hook_callbacks::class, 'extend_secondary_navigation'],
-        'priority' => 500,
+$capabilities = [
+    // Capability to manage custom clean url.
+    'local/customcleanurl:managecustomcleanurl' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
     ],
 ];

--- a/define_custom_url.php
+++ b/define_custom_url.php
@@ -48,8 +48,6 @@ require_login(null, false);
 if (!has_capability('local/customcleanurl:managecustomcleanurl', $context)) {
     throw new moodle_exception('invalidaccess', 'local_customcleanurl');
 }
-// Admin external page setup.
-admin_externalpage_setup('local_customcleanurl_defineurl');
 
 // This page is only usable when the "define custom url" clean-url type is
 // enabled, on top of the overall custom clean url feature being enabled.

--- a/define_custom_url.php
+++ b/define_custom_url.php
@@ -15,6 +15,11 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Admin page for defining custom clean urls.
+ *
+ * Lets a site admin map default Moodle urls to custom clean urls: shows an
+ * add/edit form plus a paginated, sortable, and filterable list of existing
+ * mappings, and handles add/edit/delete actions for local_customcleanurl.
  *
  * @package    local_customcleanurl
  * @copyright  2025 https://santoshmagar.com.np/
@@ -28,28 +33,33 @@ use core\output\html_writer;
 use local_customcleanurl\handler\customcleanurl_handler;
 use local_customcleanurl\local\helper;
 
-// Get require config file.
+// Bootstrap Moodle - Get require config file.
 require_once(dirname(__FILE__) . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 defined('MOODLE_INTERNAL') || die();
 
-// Get parameter.
+// Get request parameters.
 $id = optional_param('id', 0, PARAM_INT);
 $action = optional_param('action', '', PARAM_TEXT);
 $context = \context_system::instance();
 
-// Access checks and Capability check.
+// Only site admins (or anyone with moodle/site:config) may manage custom urls.
 require_login(null, false);
 if (!has_capability('moodle/site:config', $context)) {
     throw new moodle_exception('invalidaccess', 'local_customcleanurl');
 }
+// Admin external page setup.
+admin_externalpage_setup('local_customcleanurl_defineurl');
+
+// This page is only usable when the "define custom url" clean-url type is
+// enabled, on top of the overall custom clean url feature being enabled.
 $cleanurloptions = get_config('local_customcleanurl', 'cleanurl_type');
 $cleanurloptions = explode(",", $cleanurloptions);
 if (!(in_array('defineurl', $cleanurloptions) && helper::is_enable_customcleanurl())) {
     throw new moodle_exception('featureisnotenable', 'local_customcleanurl');
 }
 
-// Prepare the page information.
+// Page setup - Prepare the page information.
 $pagepath = '/local/customcleanurl/define_custom_url.php';
 $pageurl = new moodle_url($pagepath);
 $pagetitle = get_string('define_custom_url', 'local_customcleanurl');
@@ -61,36 +71,45 @@ $PAGE->set_pagelayout('admin');
 $PAGE->set_pagetype('define_custom_url');
 $PAGE->set_title($pagetitle);
 $PAGE->set_heading($pagetitle);
+$PAGE->navbar->add(get_string('pluginname', 'local_customcleanurl'), '/admin/category.php?category=local_customcleanurl');
 $PAGE->navbar->add($pagetitle);
 $PAGE->set_blocks_editing_capability('moodle/site:manageblocks');
 $PAGE->requires->jquery();
 
-// FORM actions.
+// Build the add/edit form (shared for both add and edit via the moodleform's
+// internal state; 'type' => 'defineurl' tells it which clean-url type it's for).
 $definecustomurlform = new \local_customcleanurl\form\customcleanurl_form(null, ['type' => 'defineurl']);
 
 if ($definecustomurlform->is_cancelled()) {
-    redirect($pageurl);
+    // User cancelled the form: go back to a clean listing page.
+    $returnurl = optional_param('returnurl', '', PARAM_URL);
+    redirect($returnurl ? $returnurl : $pageurl);
 } else if ($formdata = $definecustomurlform->get_data()) {
+    // Valid submission: persist the mapping (handles both add and edit internally).
     customcleanurl_handler::save_data($formdata, $pageurl, 'defineurl');
 } else {
-    if ($action && $id) {
-        // Verify sesskey.
+    if ($action) {
+        // Any GET action (edit/delete) must carry a valid sesskey.
         $sesskey = required_param('sesskey', PARAM_ALPHANUM);
         if ($sesskey != sesskey()) {
             redirect($pageurl, get_string('invalidsesskey', 'local_customcleanurl'));
         }
-        // For Delete.
-        if ($action == 'delete') {
+        // Delete an existing mapping.
+        if ($action == 'delete' && $id) {
             customcleanurl_handler::delete_data($id, $pageurl);
         }
-        // For Edit.
-        if ($action == 'edit') {
+        // Load an existing mapping into the form for editing.
+        if ($action == 'edit' && $id) {
             customcleanurl_handler::edit_form($definecustomurlform, $id, $pageurl);
+        }
+        // Prepare the form for adding a new mapping.
+        if ($action == 'edit' && !$id) {
+            customcleanurl_handler::add_form($definecustomurlform);
         }
     }
 }
 
-// Get the data and display.
+// Build the page content: the add/edit form followed by the list of mappings.
 $contents = '';
 $contents .= html_writer::start_tag('div', ['class' => 'add-custom-url-wrapper mt-4 mb-4']);
 $contents .= html_writer::tag('h3', get_string('add_new_url', 'local_customcleanurl'));
@@ -101,7 +120,7 @@ $contents .= html_writer::tag('h3', get_string('list_custom_url', 'local_customc
 $contents .= customcleanurl_handler::get_custom_url_data_table($pagepath, 50, 'defineurl');
 $contents .= html_writer::end_tag('div');
 
-// Output Content.
+// Render the page.
 echo $OUTPUT->header();
 echo $contents;
 echo $OUTPUT->footer();

--- a/define_custom_url.php
+++ b/define_custom_url.php
@@ -43,9 +43,9 @@ $id = optional_param('id', 0, PARAM_INT);
 $action = optional_param('action', '', PARAM_TEXT);
 $context = \context_system::instance();
 
-// Only site admins (or anyone with moodle/site:config) may manage custom urls.
+// Only users with the plugin capability may manage custom urls.
 require_login(null, false);
-if (!has_capability('moodle/site:config', $context)) {
+if (!has_capability('local/customcleanurl:managecustomcleanurl', $context)) {
     throw new moodle_exception('invalidaccess', 'local_customcleanurl');
 }
 // Admin external page setup.
@@ -64,7 +64,6 @@ $pagepath = '/local/customcleanurl/define_custom_url.php';
 $pageurl = new moodle_url($pagepath);
 $pagetitle = get_string('define_custom_url', 'local_customcleanurl');
 
-// Setup page information.
 $PAGE->set_context($context);
 $PAGE->set_url($pageurl);
 $PAGE->set_pagelayout('admin');

--- a/define_urlredirect.php
+++ b/define_urlredirect.php
@@ -59,6 +59,7 @@ $PAGE->set_pagelayout('admin');
 $PAGE->set_pagetype('define_urlredirect');
 $PAGE->set_title($pagetitle);
 $PAGE->set_heading($pagetitle);
+$PAGE->navbar->add(get_string('pluginname', 'local_customcleanurl'), '/admin/category.php?category=local_customcleanurl');
 $PAGE->navbar->add($pagetitle);
 $PAGE->set_blocks_editing_capability('moodle/site:manageblocks');
 $PAGE->requires->jquery();

--- a/define_urlredirect.php
+++ b/define_urlredirect.php
@@ -39,7 +39,7 @@ $context = \context_system::instance();
 
 // Access checks and Capability check.
 require_login(null, false);
-if (!has_capability('moodle/site:config', $context)) {
+if (!has_capability('local/customcleanurl:manageurlredirect', $context)) {
     throw new moodle_exception('invalidaccess', 'local_customcleanurl');
 }
 $enableurlredirect = get_config('local_customcleanurl', 'enable_urlredirect');

--- a/lang/en/local_customcleanurl.php
+++ b/lang/en/local_customcleanurl.php
@@ -73,15 +73,16 @@ This will change the default moodle url to clean url.
 </ol>
 ';
 
+$string['generalsettings'] = 'General settings';
 $string['define_urlredirect'] = 'Define URL Redirect';
 $string['enable_urlredirect'] = 'Enable url redirect';
 $string['enable_urlredirect_desc'] = 'URLs are redirected to the next destination URL.';
-$string['enable_urlredirect_descwithlink'] = ' <br> Now you can define url redirect for the existing moodle url at <a href="{$a->url}" target="_blank">HERE - URL Redirect</a>.';
+$string['enable_urlredirect_descwithlink'] = ' <br> Now you can define url redirect for the existing moodle url at <a href="{$a->url}" target="_blank" class="btn btn-primary">HERE - URL Redirect</a>.';
 $string['list_custom_urlredirect'] = 'List of custom url redirect';
 $string['add_new_url_redirect'] = 'Add new url redirect';
 $string['destination_url'] = 'Destination URL';
 $string['clean_url_type'] = 'Custom Clean URL Type';
-$string['define_custom_urldesc'] = 'Now you can define custom url for the existing moodle url at <a href="{$a->url}" target="_blank" >HERE - Define Custom URL</a>.';
+$string['define_custom_urldesc'] = 'Now you can define custom url for the existing moodle url at <a href="{$a->url}" target="_blank" class="btn btn-primary">HERE - Define Custom URL</a>';
 $string['error404_content'] = '404 Page Content';
 $string['error404_content_desc'] = 'Content which is shown in 404 error Page.';
 
@@ -101,12 +102,13 @@ $string['error_custom_url_path'] = 'Provided path "{$a->custom_url}" must start 
 $string['error_custom_exist'] = 'Provided URL "{$a->custom_url}" alrady taken.';
 $string['error_custom_url_not_originalurl'] = 'Provided URL "{$a->custom_url}" is not the default original URL.';
 $string['error_customurlparam'] = 'Custom Clean url cannot have parameter.';
+$string['error_url_too_long'] = 'URL is too long.';
 
 $string['edit_custom_url_title'] = 'Edit custom url';
-$string['data_saved'] = 'Data is sucesfully saved.';
-$string['data_updated'] = 'Data is sucesfully updated.';
+$string['data_saved'] = 'Custom Clean URL data is sucesfully saved.';
+$string['data_updated'] = 'Custom Clean URL data is sucesfully updated.';
 $string['data_saved_error'] = 'Data error on save.';
 $string['something_went_wrong'] = 'Something went wrong.';
-$string['data_delete'] = 'successfully deleted.';
-$string['data_delete_missing'] = 'Delete data is missing.';
-$string['data_edit_missing'] = 'Edit data is missing.';
+$string['data_delete'] = 'Custom Clean URL data successfully deleted.';
+$string['data_delete_missing'] = 'Custom Clean URL delete data is missing.';
+$string['data_edit_missing'] = 'Custom Clean URL edit data is missing.';

--- a/lang/en/local_customcleanurl.php
+++ b/lang/en/local_customcleanurl.php
@@ -24,6 +24,7 @@
  *
  */
 
+// phpcs:ignoreFile moodle.Files.LangFilesOrdering.IncorrectOrder
 defined('MOODLE_INTERNAL') || die();
 
 $string['pluginname'] = 'Custom Clean URL';

--- a/lang/en/local_customcleanurl.php
+++ b/lang/en/local_customcleanurl.php
@@ -112,3 +112,6 @@ $string['something_went_wrong'] = 'Something went wrong.';
 $string['data_delete'] = 'Custom Clean URL data successfully deleted.';
 $string['data_delete_missing'] = 'Custom Clean URL delete data is missing.';
 $string['data_edit_missing'] = 'Custom Clean URL edit data is missing.';
+
+$string['customcleanurl:managecustomcleanurl'] = 'Manage custom clean URLs';
+$string['customcleanurl:manageurlredirect'] = 'Manage URL redirects';

--- a/settings.php
+++ b/settings.php
@@ -15,7 +15,12 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Setting file.
+ * Admin settings for local_customcleanurl.
+ *
+ * Registers a category node under "Local plugins" in the admin tree, containing:
+ * - A "General settings" page (admin_settingpage) with the plugin's config options.
+ * - A "Define Custom URL" external page, shown only when that clean-url type is enabled.
+ * - A "Define URL Redirect" external page, shown only when url redirect is enabled.
  *
  * @package    local_customcleanurl
  * @copyright  2025 https://santoshmagar.com.np/
@@ -31,33 +36,53 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/adminlib.php');
 
+$componentname = 'local_customcleanurl';
+
 if ($hassiteconfig) {
     $checkrewritehtaccess = '';
     $isenablecustomcleanurl = helper::is_enable_customcleanurl();
+    $cleanurloptions = get_config($componentname, 'cleanurl_type');
+    $cleanurloptions = $cleanurloptions ? explode(",", $cleanurloptions) : [];
     $customcleanurlroutecheck = false;
 
-    // ... Heading.
-    $settings = new admin_settingpage('local_customcleanurl', get_string('pluginname', 'local_customcleanurl'));
-    $ADMIN->add('localplugins', $settings);
+    // Current admin tree section/category, used below to show the route-check
+    // notice only when the user is actually viewing this plugin's settings.
+    $section = optional_param('section', '', PARAM_TEXT);
+    $category = optional_param('category', '', PARAM_TEXT);
 
-    // ... Enable custom clean url
-    $name = 'local_customcleanurl/enable_customcleanurl';
-    $title = get_string('enable_customcleanurl', 'local_customcleanurl');
+    // Category node: groups all of this plugin's admin pages together under
+    // "Local plugins", instead of a single flat settings page.
+    $ADMIN->add('localplugins', new admin_category(
+        $componentname,
+        get_string('pluginname', $componentname)
+    ));
+
+    // Main "General settings" page, added into the category above.
+    $settings = new admin_settingpage(
+        'local_customcleanurl_settings',
+        get_string('generalsettings', $componentname)
+    );
+
+    // Enable/disable the whole custom clean url feature.
+    $name = $componentname . '/enable_customcleanurl';
+    $title = get_string('enable_customcleanurl', $componentname);
     $description = '';
     if ($isenablecustomcleanurl) {
-        $section = optional_param('section', '', PARAM_TEXT);
-        if ($section == 'local_customcleanurl') {
+        // Only run the htaccess/route check when this plugin's own admin
+        // page (settings page or category overview) is being displayed,
+        // to avoid the extra check firing on unrelated admin pages.
+        if ($section == 'local_customcleanurl_settings' || $category == $componentname) {
             $customcleanurlroutecheck = helper::customcleanurl_routecheck();
             if ($customcleanurlroutecheck) {
                 $description .= html_writer::tag(
                     'div',
-                    get_string('pass_customcleanurlroutecheck', 'local_customcleanurl'),
+                    get_string('pass_customcleanurlroutecheck', $componentname),
                     ["class" => "alert alert-info alert-block fade in  alert-dismissible"]
                 );
             } else {
                 $description .= html_writer::tag(
                     'div',
-                    get_string('fail_customcleanurlroutecheck', 'local_customcleanurl'),
+                    get_string('fail_customcleanurlroutecheck', $componentname),
                     ["class" => "alert alert-danger alert-block fade in  alert-dismissible"]
                 );
                 $description .= html_writer::tag(
@@ -71,51 +96,79 @@ if ($hassiteconfig) {
     $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
     $settings->add($setting);
 
-    // ... Enable url redirect
-    $name = 'local_customcleanurl/enable_urlredirect';
-    $title = get_string('enable_urlredirect', 'local_customcleanurl');
-    $description = get_string('enable_urlredirect_desc', 'local_customcleanurl');
-    $enableurlredirect = get_config('local_customcleanurl', 'enable_urlredirect');
+    // Enable/disable the url redirect feature.
+    $name = $componentname . '/enable_urlredirect';
+    $title = get_string('enable_urlredirect', $componentname);
+    $description = get_string('enable_urlredirect_desc', $componentname);
+    $enableurlredirect = get_config($componentname, 'enable_urlredirect');
     if ($enableurlredirect) {
         $a = new stdClass();
         $a->url = (new moodle_url('/local/customcleanurl/define_urlredirect.php'))->out(false);
-        $description .= get_string('enable_urlredirect_descwithlink', 'local_customcleanurl', $a);
+        $description .= get_string('enable_urlredirect_descwithlink', $componentname, $a);
     }
     $setting = new admin_setting_configcheckbox($name, $title, $description, 0);
     $settings->add($setting);
 
-    // ... after enable enable_customcleanurl, check route.
+    // Remaining settings only make sense once custom clean url is enabled.
     if ($isenablecustomcleanurl) {
-        // ... define custom url type.
+        // Which type(s) of clean url are active: course, user, and/or defined custom url.
         $checkboxoptions  = [
-            'courseurl' => get_string('course_url', 'local_customcleanurl'),
-            'userurl' => get_string('user_url', 'local_customcleanurl'),
-            'defineurl' => get_string('define_custom_url', 'local_customcleanurl'),
+            'courseurl' => get_string('course_url', $componentname),
+            'userurl' => get_string('user_url', $componentname),
+            'defineurl' => get_string('define_custom_url', $componentname),
         ];
         $defaultvalues = [
             'courseurl' => 0,
             'userurl' => 0,
             'defineurl' => 1,
         ];
-        $name = 'local_customcleanurl/cleanurl_type';
-        $title = get_string('clean_url_type', 'local_customcleanurl');
-        $description = get_string('cleanurl_options_desc', 'local_customcleanurl');
-        // ... define custom url link
-        $cleanurloptions = get_config('local_customcleanurl', 'cleanurl_type');
-        $cleanurloptions = explode(",", $cleanurloptions);
+        $name = $componentname . '/cleanurl_type';
+        $title = get_string('clean_url_type', $componentname);
+        $description = get_string('cleanurl_options_desc', $componentname);
         if (in_array('defineurl', $cleanurloptions)) {
             $a = new stdClass();
             $a->url = (new moodle_url('/local/customcleanurl/define_custom_url.php'))->out(false);
-            $description .= get_string('define_custom_urldesc', 'local_customcleanurl', $a);
+            $description .= get_string('define_custom_urldesc', $componentname, $a);
         }
         $setting = new admin_setting_configmulticheckbox($name, $title, $description, $defaultvalues, $checkboxoptions);
         $settings->add($setting);
 
-        // ... 404 error page content
-        $name = 'local_customcleanurl/error404_content';
-        $title = get_string('error404_content', 'local_customcleanurl');
-        $description = get_string('error404_content_desc', 'local_customcleanurl');
+        // Custom content shown on the plugin's 404 error page.
+        $name = $componentname . '/error404_content';
+        $title = get_string('error404_content', $componentname);
+        $description = get_string('error404_content_desc', $componentname);
         $setting = new admin_setting_confightmleditor($name, $title, $description, '');
         $settings->add($setting);
     }
+
+    // Register the general settings page under the category.
+    $ADMIN->add($componentname, $settings);
+
+    if ($category != 'local_customcleanurl') {
+        // "Define Custom URL" sub-page — only listed when that clean-url type is enabled.
+        if ($isenablecustomcleanurl && in_array('defineurl', $cleanurloptions)) {
+            $ADMIN->add(
+                $componentname,
+                new admin_externalpage(
+                    'local_customcleanurl_defineurl',
+                    get_string('define_custom_url', $componentname),
+                    new moodle_url('/local/customcleanurl/define_custom_url.php')
+                )
+            );
+        }
+
+        // "Define URL Redirect" sub-page — only listed when url redirect is enabled.
+        $enableurlredirect = get_config($componentname, 'enable_urlredirect');
+        if ($enableurlredirect) {
+            $ADMIN->add(
+                $componentname,
+                new admin_externalpage(
+                    'local_customcleanurl_urlredirect',
+                    get_string('define_urlredirect', $componentname),
+                    new moodle_url('/local/customcleanurl/define_urlredirect.php')
+                )
+            );
+        }
+    }
+
 }

--- a/settings.php
+++ b/settings.php
@@ -145,7 +145,7 @@ if ($hassiteconfig) {
     $ADMIN->add($componentname, $settings);
 
     if ($category != 'local_customcleanurl') {
-        // "Define Custom URL" sub-page — only listed when that clean-url type is enabled.
+        // ... "Define Custom URL" sub-page — only listed when that clean-url type is enabled.
         if ($isenablecustomcleanurl && in_array('defineurl', $cleanurloptions)) {
             $ADMIN->add(
                 $componentname,
@@ -158,7 +158,7 @@ if ($hassiteconfig) {
             );
         }
 
-        // "Define URL Redirect" sub-page — only listed when url redirect is enabled.
+        // ... "Define URL Redirect" sub-page — only listed when url redirect is enabled.
         $enableurlredirect = get_config($componentname, 'enable_urlredirect');
         if ($enableurlredirect) {
             $ADMIN->add(
@@ -172,5 +172,4 @@ if ($hassiteconfig) {
             );
         }
     }
-
 }

--- a/settings.php
+++ b/settings.php
@@ -152,7 +152,8 @@ if ($hassiteconfig) {
                 new admin_externalpage(
                     'local_customcleanurl_defineurl',
                     get_string('define_custom_url', $componentname),
-                    new moodle_url('/local/customcleanurl/define_custom_url.php')
+                    new moodle_url('/local/customcleanurl/define_custom_url.php'),
+                    'local/customcleanurl:managecustomcleanurl'
                 )
             );
         }
@@ -165,7 +166,8 @@ if ($hassiteconfig) {
                 new admin_externalpage(
                     'local_customcleanurl_urlredirect',
                     get_string('define_urlredirect', $componentname),
-                    new moodle_url('/local/customcleanurl/define_urlredirect.php')
+                    new moodle_url('/local/customcleanurl/define_urlredirect.php'),
+                    'local/customcleanurl:manageurlredirect'
                 )
             );
         }

--- a/version.php
+++ b/version.php
@@ -31,10 +31,10 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'local_customcleanurl';
 
 // This is the named version.
-$plugin->release = '1.1.6';
+$plugin->release = '1.1.7';
 
 // This is the version of the plugin.
-$plugin->version = 2026091500;
+$plugin->version = 2026092800;
 
 // This is a stable release.
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
- Removed unnecessary cookie definition in 404.php.
- Enhanced customcleanurl_form to include a hidden return URL field.
- Improved customcleanurl_handler to handle return URL and added a new method for populating the add form.
- Updated hook_callbacks to add a secondary navigation node for defining custom URLs.
- Refined clean_url class to ensure proper URL encoding.
- Streamlined helper class methods for checking request URLs and added a method for adding navigation nodes.
- Introduced capabilities for managing custom clean URLs in access.php.
- Registered hooks for secondary navigation extension in hooks.php.
- Enhanced define_custom_url.php and define_urlredirect.php for better navigation and functionality.
- Updated language strings for clarity and consistency.
- Improved settings.php to organize admin settings and ensure proper feature checks.